### PR TITLE
Fixed vertical and horizontal misalignment on iPhone 6 Plus

### DIFF
--- a/BMGlyphLabel/BMGlyphLabel.m
+++ b/BMGlyphLabel/BMGlyphLabel.m
@@ -169,9 +169,6 @@
     CGPoint pos = CGPointZero;
     CGFloat scaleFactor;
 #if TARGET_OS_IPHONE
-    if (([[UIScreen mainScreen] respondsToSelector:@selector(nativeScale)]))
-        scaleFactor = [UIScreen mainScreen].nativeScale;
-    else
         scaleFactor = [UIScreen mainScreen].scale;
 #else
     scaleFactor = 1.0f;


### PR DESCRIPTION
nativeScale property caused letters to be both vertical and horizontal misaligned on iPhone 6 Plus.
I can see this is already fixed in BMGlyphFont class.
